### PR TITLE
Depend on python-htcondor

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-cuda:10.2
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,4 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cos7-cuda:10.2
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -45,8 +49,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -61,11 +69,13 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/htmap-feedstock
 
 Summary: High-Throughput Computing in Python, powered by HTCondor
 
-Development: https://github.com/htcondor/htmap
+Development: https://github.com/htcondor/htmap.git
 
 Documentation: https://htmap.readthedocs.io/
 
@@ -120,9 +120,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,3 @@
 conda_forge_output_validation: true
+os_version:
+  linux_64: cos7

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-cuda_compiler_version:                    # [linux64]
-  - None                                  # [linux64]
-docker_image:                             # [linux64]
-  - condaforge/linux-anvil-cos7-x86_64    # [linux64]
-cdt_name:                                 # [linux64]
-  - cos7                                  # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,20 +13,21 @@ build:
   entry_points:
     - htmap = htmap.cli:cli
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
     - python >=3.6
+    - setuptools >=40.6.0
   run:
     - click >=7.0,<8.0.0a0
     - click-didyoumean >=0.0.3,<0.1.0a0
     - cloudpickle >=1.4,<2.0.0a0
     - halo >=0.0.28,<0.1.0a0
-    - htcondor >=8.8.0
     - python >=3.6
+    - python-htcondor >=8.8.0
     - toml >=0.10.0,<1.0.0a0
     - tqdm >=4.36,<5.0.0a0
 
@@ -39,7 +40,7 @@ test:
 about:
   home: https://htmap.readthedocs.io/
   doc_url: https://htmap.readthedocs.io/
-  dev_url: https://github.com/htcondor/htmap
+  dev_url: https://github.com/htcondor/htmap.git
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE


### PR DESCRIPTION
This PR modifies the recipe to depend only upon python-htcondor, and not the full htcondor stack.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
